### PR TITLE
chore: updated prerelease commands due to entrypoint

### DIFF
--- a/.aptible.yml
+++ b/.aptible.yml
@@ -1,2 +1,2 @@
 before_release:
-  - python manage.py migrate
+  - manage.py migrate


### PR DESCRIPTION
Previously would see errors like this:

```sh
python3: can't open file '/app/python3': [Errno 2] No such file or directory
```

This works, but apparently entrypoint causes this issue:

<img width="831" alt="image" src="https://user-images.githubusercontent.com/2961973/235524601-b51dab06-da7a-406b-b14f-d6dc027b8e17.png">
