### PR TITLE
chore: cmd correction (dropping entrypoint)

### DIFF
--- a/.aptible.yml
+++ b/.aptible.yml
@@ -1,2 +1,2 @@
 before_release:
-  - manage.py migrate
+  - python3 manage.py migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,4 @@ WORKDIR /app
 COPY requirements.txt /app
 RUN pip3 install -r requirements.txt --no-cache-dir
 COPY . /app 
-ENTRYPOINT ["python3"] 
-CMD ["manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
this happened here: https://github.com/aptible/template-django/pull/4

but i did not see this comment and lost tabs on it, as it was 💯 and on point


---

## Replicating issue as suggested by Frank

To fully duplicate the concern (and someone has run into it using the demo app (05/12 early morning hours):

<img width="554" alt="image" src="https://github.com/aptible/template-django/assets/2961973/ba895a2c-669c-4d47-b081-40ea64b20f28">

## Fixing (dropping entrypoint)

This change ran migrations without issue:

<img width="663" alt="image" src="https://github.com/aptible/template-django/assets/2961973/e7baf3d0-cc94-4db9-a63e-d5266e48119f">

<img width="767" alt="image" src="https://github.com/aptible/template-django/assets/2961973/353d1509-9a9e-4ff4-aef3-61f301d28c4f">

<img width="566" alt="image" src="https://github.com/aptible/template-django/assets/2961973/7c3d9565-0e3c-4e8e-9c21-ae2f3b243611">
